### PR TITLE
implement likes/dislikes (buggy)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -129,7 +129,14 @@ function App() {
 						{events && (
 							<div className="flex flex-col space-y-4">
 								{events.map((event, i) => {
-									return <DisplayEventCard event={event} getEvents={getEvents} key={i} showEvent={showEventsLoader}/>
+									return <DisplayEventCard 
+														pk={pk ? pk : null} 
+										        event={event} 
+										        getEvents={getEvents} 
+										        key={i} 
+										        showEvent={showEventsLoader}
+														publishEvent={publishEvent}		
+									/>
 								})}
 							</div>
 						)}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,9 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { 
 	getPublicKey, relayInit, Event, 
 	getEventHash, signEvent, Relay, 
 	UnsignedEvent, Filter,
 } from 'nostr-tools';
-import { BsMoonStarsFill } from "react-icons/bs";
-import { FaSun } from "react-icons/fa";
 
 
 import './App.css';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -128,12 +128,12 @@ function App() {
 
 						{events && (
 							<div className="flex flex-col space-y-4">
-								{events.map((event, i) => {
+								{events.map((event) => {
 									return <DisplayEventCard 
 														pk={pk ? pk : null} 
 										        event={event} 
 										        getEvents={getEvents} 
-										        key={i} 
+										        key={event.id} 
 										        showEvent={showEventsLoader}
 														publishEvent={publishEvent}		
 									/>

--- a/src/components/displayEventCard.tsx
+++ b/src/components/displayEventCard.tsx
@@ -1,15 +1,52 @@
-import { useProfile } from "nostr-react";
-import { Filter, type Event } from "nostr-tools";
+import { useProfile, useNostrEvents } from "nostr-react";
+import { Filter, type Event, UnsignedEvent } from "nostr-tools";
+import { useEffect, useState } from "react";
+import { FcLike, FcDislike } from "react-icons/fc"
 
 
 interface DisplayEventCardProps {
-	event: Event
+	pk: string | null,
+	event: Event,
 	showEvent: boolean,
 	getEvents: (filters: Filter[]) => void,
+	publishEvent: (event: UnsignedEvent, _sk?: string) => void,
 }
 
 export default function DisplayEventCard(props: DisplayEventCardProps) {
 	const {data: userData} = useProfile({pubkey: props.event.pubkey});
+	const [liked, setLiked] = useState<boolean>(false);
+	const [disliked, setDisliked] = useState<boolean>(false);
+	const reactions = useNostrEvents({
+			filter: {
+				"#e": [props.event.id],
+				kinds: [7],
+			},
+	}).events;
+
+	const getReactionCount = (reactions: Event[], reactionType: string): number => {
+		let count: number = 0;
+		for (let reaction of reactions) {
+			if (reaction.content == reactionType) count++;
+		}
+		
+		return count;
+	}
+
+	useEffect(() => {
+		if (reactions) {
+			for (let reaction of reactions) {
+				if (reaction.pubkey == props.pk && reaction.content == "+") {
+					setLiked(true);
+				} else if (reaction.pubkey == props.pk && reaction.content == "-") {
+					setDisliked(true);
+				} else {
+					setLiked(false);
+					setDisliked(false);
+				}
+			}
+		}
+	}, [reactions])
+
 
 	return (
 		<div className="divide-y divide-white overflow-hidden rounded-lg bg-gray-200 dark:bg-[#1a1a1a] shadow border border-dashed border-green-300" hidden={props.showEvent ? true : false}>
@@ -42,6 +79,62 @@ export default function DisplayEventCard(props: DisplayEventCardProps) {
   			<div className="mt-2">
 					<span className="text-lg">{props.event.content}</span>					
   			</div>
+  		</div>
+  		<div 
+				className="px-4 py-5 sm:px-6 text-lg"
+			>
+				<div className="flex flex-row justify-start space-x-1">
+					<button className={disliked ? "bg-green-300/25 border border-white hover:bg-green-300/25" : "border border-white hover:bg-green-300/25"}
+						onClick={() => {
+							if (!props.pk) return;
+
+							if (liked) setLiked(false);
+							setDisliked(current => current ? false : true);
+
+							props.publishEvent({
+								kind: 7,
+								content: "-",
+							  created_at: Math.floor(Date.now() / 1000),
+								tags: [
+									["e", props.event.id],
+									["p", props.event.pubkey],
+								],
+								pubkey: props.pk, 
+							});
+						}}
+					>
+						<div className="flex flex-row items-center space-x-2">
+							<FcDislike className="h-5 w-5 hover:cursor-pointer"/>
+							<span>
+								{getReactionCount(reactions, "-")}
+							</span>
+						</div>
+					</button>
+					<button className={liked ? "bg-green-300/25 border border-white hover:bg-green-300/25" : "border border-white hover:bg-green-300/25"}
+						onClick={() => {
+							if (!props.pk) return;
+
+							if (disliked) setDisliked(false);
+							setLiked(current => current ? false : true);
+
+							props.publishEvent({
+								kind: 7,
+								content: "+",
+							  created_at: Math.floor(Date.now() / 1000),
+								tags: [
+									["e", props.event.id],
+									["p", props.event.pubkey],
+								],
+								pubkey: props.pk, 
+							});
+						}}
+					>
+						<div className="flex flex-row items-center space-x-2">
+							<FcLike className="h-5 w-5 hover:cursor-pointer"/>
+							<span>{getReactionCount(reactions, "+")}</span>
+						</div>
+					</button>
+				</div>
   		</div>
 		</div>
 	)

--- a/src/components/displayEventCard.tsx
+++ b/src/components/displayEventCard.tsx
@@ -88,7 +88,7 @@ export default function DisplayEventCard(props: DisplayEventCardProps) {
 				className="px-4 py-5 sm:px-6 text-lg"
 			>
 				<div className="flex flex-row justify-start space-x-1">
-					<button className={userDisliked ? "bg-green-300/25 border border-white hover:bg-green-300/25" : "border border-white hover:bg-green-300/25"}
+					<button className={userDisliked ? "bg-green-300/25 border border-white hover:bg-green-300/25" : "bg-black/25 dark:bg-white/25 border border-white hover:bg-green-300/25"}
 						onClick={() => {
 							if (!props.pk) return;
 
@@ -109,12 +109,12 @@ export default function DisplayEventCard(props: DisplayEventCardProps) {
 					>
 						<div className="flex flex-row items-center space-x-2">
 							<FcDislike className="h-5 w-5 hover:cursor-pointer"/>
-							<span>
+							<span className={userDisliked ? "text-green-700 dark:text-white" : "text-white"}>
 								{nDislikes}
 							</span>
 						</div>
 					</button>
-					<button className={userLiked ? "bg-green-300/25 border border-white hover:bg-green-300/25" : "border border-white hover:bg-green-300/25"}
+					<button className={userLiked ? "bg-green-300/25 border border-white hover:bg-green-300/25" : "bg-black/25 dark:bg-white/25 border border-white hover:bg-green-300/25"}
 						onClick={() => {
 							if (!props.pk) return;
 
@@ -135,7 +135,7 @@ export default function DisplayEventCard(props: DisplayEventCardProps) {
 					>
 						<div className="flex flex-row items-center space-x-2">
 							<FcLike className="h-5 w-5 hover:cursor-pointer"/>
-							<span>{nLikes}</span>
+							<span className={userLiked ? "text-green-700 dark:text-white" : "text-white"}>{nLikes}</span>
 						</div>
 					</button>
 				</div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,7 +11,10 @@ export const RELAYS = [
   "wss://relay.damus.io",
 ];
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+
+let root = document.getElementById('root');
+root?.classList.add('dark:bg-[#242424]');
+ReactDOM.createRoot(root as HTMLElement).render(
   <React.StrictMode>
 		<NostrProvider relayUrls={RELAYS} debug={true}>
     	<App />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,7 @@ export const RELAYS = [
 
 
 let root = document.getElementById('root');
+root?.classList.add('bg-white');
 root?.classList.add('dark:bg-[#242424]');
 ReactDOM.createRoot(root as HTMLElement).render(
   <React.StrictMode>


### PR DESCRIPTION
Implemented event "reactions" from the NIP below:
====

NIP-25
======

Reactions
---------

`draft` `optional` `author:jb55`

A reaction is a `kind 7` note that is used to react to other notes.

The generic reaction, represented by the `content` set to a `+` string, SHOULD
be interpreted as a "like" or "upvote".

A reaction with `content` set to `-` SHOULD be interpreted as a "dislike" or
"downvote". It SHOULD NOT be counted as a "like", and MAY be displayed as a
downvote or dislike on a post. A client MAY also choose to tally likes against
dislikes in a reddit-like system of upvotes and downvotes, or display them as
separate tallies.

The `content` MAY be an emoji, in this case it MAY be interpreted as a "like" or "dislike",
or the client MAY display this emoji reaction on the post.

Tags
----

The reaction event SHOULD include `e` and `p` tags from the note the user is
reacting to. This allows users to be notified of reactions to posts they were
mentioned in. Including the `e` tags enables clients to pull all the reactions
associated with individual posts or all the posts in a thread.

The last `e` tag MUST be the `id` of the note that is being reacted to. 

The last `p` tag MUST be the `pubkey` of the event being reacted to.

Example code

```swift
func make_like_event(pubkey: String, privkey: String, liked: NostrEvent) -> NostrEvent {
    var tags: [[String]] = liked.tags.filter { 
    	tag in tag.count >= 2 && (tag[0] == "e" || tag[0] == "p") 
    }
    tags.append(["e", liked.id])
    tags.append(["p", liked.pubkey])
    let ev = NostrEvent(content: "+", pubkey: pubkey, kind: 7, tags: tags)
    ev.calculate_id()
    ev.sign(privkey: privkey)
    return ev
}